### PR TITLE
Add a skeleton for nicer doc landing page

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(documentation (package dreamtt))

--- a/index.mld
+++ b/index.mld
@@ -1,0 +1,21 @@
+{0 dreamtt}
+
+Welcome to Dreamtt's documentation!
+
+{1 Overview}
+
+Dreamtt is a pedagogic implementation of abstract bidirectional elaboration for dependent type theory.
+
+It is internally organized into 3 parts:
+
+- [Basis] defines functional concepts such as [Monad] and technical utilities like [Pp] (a pretty-printer)
+- [Core] implements the internal AST and the key algorithms
+- [Frontend] provides the user-facing parts, i.e., the surface language
+
+{1 API documentation}
+
+{!modules:
+Basis
+Core
+Frontend
+}


### PR DESCRIPTION
Currently http://www.jonmsterling.com/dreamtt/dreamtt/index.html seems rather uninformative, this is an attempt to make the documentation a bit more helpful :)